### PR TITLE
ci(workflow): 扩展 CI 支持多平台测试并增强模块加载检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # windows-latest, macos-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
         neovim: [stable]
     runs-on: ${{ matrix.os }}
     steps:
@@ -58,13 +58,34 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake make gcc g++
 
+      - name: Install build tools (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          brew update
+          brew install cmake || true
+          cmake --version || true
+
+      - name: Install build tools (Windows)
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: |
+          choco install -y cmake make
+          cmake --version
+          make --version
+
+      - name: Prepare artifacts dir
+        shell: bash
+        run: |
+          rm -rf artifacts && mkdir -p artifacts
+
       - name: Basic commands
         shell: bash
         run: |
           nvim -V1 -v
           nvim -V1 -v -Es \
             +"lua vim.opt.runtimepath:append(vim.fn.getcwd()); require('quick-c').setup({})" \
-            +QuickCHealth +QuickCCheck +QuickCReload +QuickCConfig +messages +qall!
+            +QuickCHealth +QuickCCheck +QuickCReload +QuickCConfig +messages +qall! | tee -a artifacts/ci.log
 
       - name: Probe setup error (diagnostic)
         shell: bash
@@ -72,8 +93,82 @@ jobs:
           set +e
           nvim -V1 -v -Es \
             +"lua local ok,err=pcall(function() vim.opt.runtimepath:append(vim.fn.getcwd()); require('quick-c').setup({}) end); if not ok then print('SETUP_ERR:'..tostring(err)) end" \
-            +messages +qall!
+            +messages +qall! | tee -a artifacts/ci.log
           echo "Probe exit code: $?" || true
+
+      - name: Module load sanity
+        shell: bash
+        run: |
+          set -e
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              local mods = { \
+                'quick-c', \
+                'quick-c.util', \
+                'quick-c.terminal', \
+                'quick-c.make', \
+                'quick-c.make_search', \
+                'quick-c.cmake', \
+                'quick-c.telescope', \
+                'quick-c.build', \
+                'quick-c.cc', \
+              }; \
+              local failed = {}; \
+              for _, m in ipairs(mods) do \
+                local ok, err = pcall(require, m); \
+                if not ok then \
+                  print('REQUIRE_FAIL:'..m..' -> '..tostring(err)); \
+                  table.insert(failed, m); \
+                else \
+                  print('REQUIRE_OK:'..m); \
+                end \
+              end \
+              if #failed > 0 then vim.cmd('cq 1') end \
+            " +qall! | tee -a artifacts/ci.log
+
+      - name: Make search (no Makefile) smoke
+        shell: bash
+        run: |
+          set -e
+          rm -rf tests/nomake && mkdir -p tests/nomake/sub
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              vim.cmd('lcd tests/nomake'); \
+              local qc = require('quick-c'); \
+              qc.setup({ make = { search = { up = 0, down = 1 } } }); \
+              local ms = require('quick-c.make_search'); \
+              local done1, root = false, nil; \
+              ms.find_make_root_async(qc._config, vim.fn.getcwd(), function(dir) root = dir; done1 = true end); \
+              if vim.wait(3000, function() return done1 end) ~= 0 then print('ROOT:'..tostring(root)) else error('find_make_root_async timeout') end; \
+              local done2, list = false, nil; \
+              ms.find_make_roots_async(qc._config, vim.fn.getcwd(), function(lst) list = lst; done2 = true end); \
+              if vim.wait(3000, function() return done2 end) ~= 0 then print('ROOTS_SZ:'..tostring(#(list or {}))) else error('find_make_roots_async timeout') end; \
+              local mk = require('quick-c.make'); \
+              local done3, parsed = false, nil; \
+              mk.parse_make_targets_in_cwd_async(qc._config, vim.fn.getcwd(), function(res) parsed = res; done3 = true end); \
+              if vim.wait(3000, function() return done3 end) ~= 0 then \
+                local n = (parsed and parsed.targets) and #parsed.targets or 0; \
+                print('PARSE_TARGETS_SZ:'..tostring(n)); \
+              else \
+                error('parse_make_targets_in_cwd_async timeout'); \
+              end \
+            " +qall! | tee -a artifacts/ci.log
+
+      - name: Telescope quickfix fallback (no telescope)
+        shell: bash
+        run: |
+          set -e
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              local ok_t = pcall(require, 'telescope'); \
+              local ok, err = pcall(function() require('quick-c.telescope').telescope_quickfix({}) end); \
+              print('TEL_PRESENT:'..tostring(ok_t)); \
+              print('QF_CALL_OK:'..tostring(ok)); \
+              if not ok then print('QF_CALL_ERR:'..tostring(err)) end; \
+            " +qall! | tee -a artifacts/ci.log
 
       - name: CMake configure smoke (Linux)
         if: runner.os == 'Linux'
@@ -92,4 +187,156 @@ jobs:
           EOF
           nvim -Es \
             +"lua vim.opt.runtimepath:append(vim.fn.getcwd()); vim.cmd('lcd tests/smoke'); require('quick-c').setup({})" \
-            +QuickCCMakeConfigure +qall!
+            +QuickCCMakeConfigure +qall! | tee -a artifacts/ci.log
+
+      - name: Picker build (no-interaction) smoke (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -e
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              vim.cmd('lcd tests/smoke'); \
+              local tel = require('quick-c.telescope'); \
+              local cfg = { make = { telescope = { preview = false } }, cmake = { telescope = { preview = false } } }; \
+              -- QuickCMake picker build with stubs (should return gracefully even without telescope) \
+              local function noop() end \
+              local function cwd_resolve(base, cb) cb(vim.fn.getcwd()) end \
+              local function parse_targets(cwd, cb) cb({ targets = {}, phony = {} }) end \
+              local function choose_make() return 'make' end \
+              local function shell_quote_path(p) return p end \
+              local function run_make_in_terminal(cmd) end \
+              pcall(function() tel.telescope_make(cfg, cwd_resolve, parse_targets, noop, choose_make, shell_quote_path, run_make_in_terminal) end); \
+              -- QuickCCMake picker build using real cmake module (should return even without telescope) \
+              pcall(function() tel.telescope_cmake(cfg) end); \
+            " +qall! | tee -a artifacts/ci.log
+
+      - name: CMake list targets (read-only, no telescope) (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -e
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              vim.cmd('lcd tests/smoke'); \
+              local qc = require('quick-c'); qc.setup({}); \
+              local CM = require('quick-c.cmake'); \
+              local base = vim.fn.getcwd(); \
+              local done1, root = false, nil; \
+              CM.resolve_root_async(qc._config, base, function(r) root = r; done1 = true end); \
+              assert(vim.wait(3000, function() return done1 end) ~= 0, 'resolve_root_async timeout'); \
+              local done2, list = false, nil; \
+              CM.list_targets_async(qc._config, root, function(t) list = t; done2 = true end); \
+              assert(vim.wait(5000, function() return done2 end) ~= 0, 'list_targets_async timeout'); \
+              local n = (list and #list) or 0; print('CMAKE_TARGETS_SZ:'..tostring(n)); \
+            " +qall! | tee -a artifacts/ci.log
+
+      - name: Picker build (no-interaction) smoke (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -e
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              local tel = require('quick-c.telescope'); \
+              local cfg = { make = { telescope = { preview = false } }, cmake = { telescope = { preview = false } } }; \
+              local function noop() end \
+              local function cwd_resolve(base, cb) cb(vim.fn.getcwd()) end \
+              local function parse_targets(cwd, cb) cb({ targets = {}, phony = {} }) end \
+              local function choose_make() return 'make' end \
+              local function shell_quote_path(p) return p end \
+              local function run_make_in_terminal(cmd) end \
+              pcall(function() tel.telescope_make(cfg, cwd_resolve, parse_targets, noop, choose_make, shell_quote_path, run_make_in_terminal) end); \
+              pcall(function() tel.telescope_cmake(cfg) end); \
+            " +qall! | tee -a artifacts/ci.log
+
+      - name: CMake list targets (read-only, no telescope) (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -e
+          mkdir -p tests/smoke
+          cat > tests/smoke/CMakeLists.txt << 'EOF'
+          cmake_minimum_required(VERSION 3.10)
+          project(foo C)
+          add_executable(foo main.c)
+          EOF
+          cat > tests/smoke/main.c << 'EOF'
+          #include <stdio.h>
+          int main(){ puts("ok"); return 0; }
+          EOF
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              vim.cmd('lcd tests/smoke'); \
+              local qc = require('quick-c'); qc.setup({}); \
+              local CM = require('quick-c.cmake'); \
+              local base = vim.fn.getcwd(); \
+              local done1, root = false, nil; \
+              CM.resolve_root_async(qc._config, base, function(r) root = r; done1 = true end); \
+              assert(vim.wait(3000, function() return done1 end) ~= 0, 'resolve_root_async timeout'); \
+              local done2, list = false, nil; \
+              CM.list_targets_async(qc._config, root, function(t) list = t; done2 = true end); \
+              assert(vim.wait(5000, function() return done2 end) ~= 0, 'list_targets_async timeout'); \
+              local n = (list and #list) or 0; print('CMAKE_TARGETS_SZ:'..tostring(n)); \
+            " +qall! | tee -a artifacts/ci.log
+
+      - name: Picker build (no-interaction) smoke (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -e
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              local tel = require('quick-c.telescope'); \
+              local cfg = { make = { telescope = { preview = false } }, cmake = { telescope = { preview = false } } }; \
+              local function noop() end \
+              local function cwd_resolve(base, cb) cb(vim.fn.getcwd()) end \
+              local function parse_targets(cwd, cb) cb({ targets = {}, phony = {} }) end \
+              local function choose_make() return 'make' end \
+              local function shell_quote_path(p) return p end \
+              local function run_make_in_terminal(cmd) end \
+              pcall(function() tel.telescope_make(cfg, cwd_resolve, parse_targets, noop, choose_make, shell_quote_path, run_make_in_terminal) end); \
+              pcall(function() tel.telescope_cmake(cfg) end); \
+            " +qall! | tee -a artifacts/ci.log
+
+      - name: CMake list targets (read-only, no telescope) (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -e
+          mkdir -p tests/smoke
+          cat > tests/smoke/CMakeLists.txt << 'EOF'
+          cmake_minimum_required(VERSION 3.10)
+          project(foo C)
+          add_executable(foo main.c)
+          EOF
+          cat > tests/smoke/main.c << 'EOF'
+          #include <stdio.h>
+          int main(){ puts("ok"); return 0; }
+          EOF
+          nvim -V1 -v -Es \
+            +"lua \
+              vim.opt.runtimepath:append(vim.fn.getcwd()); \
+              vim.cmd('lcd tests/smoke'); \
+              local qc = require('quick-c'); qc.setup({}); \
+              local CM = require('quick-c.cmake'); \
+              local base = vim.fn.getcwd(); \
+              local done1, root = false, nil; \
+              CM.resolve_root_async(qc._config, base, function(r) root = r; done1 = true end); \
+              assert(vim.wait(3000, function() return done1 end) ~= 0, 'resolve_root_async timeout'); \
+              local done2, list = false, nil; \
+              CM.list_targets_async(qc._config, root, function(t) list = t; done2 = true end); \
+              assert(vim.wait(5000, function() return done2 end) ~= 0, 'list_targets_async timeout'); \
+              local n = (list and #list) or 0; print('CMAKE_TARGETS_SZ:'..tostring(n)); \
+            " +qall! | tee -a artifacts/ci.log
+
+      - name: Upload CI logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-logs-${{ matrix.os }}-${{ matrix.neovim }}
+          path: artifacts/*.log


### PR DESCRIPTION
- 添加 macOS 和 Windows 到 CI 矩阵中，实现跨平台测试
- 为 macOS 和 Windows 添加构建工具安装步骤
- 增加模块加载完整性检查，确保所有子模块可正常 require
- 添加 Makefile 搜索功能的冒烟测试（无 Makefile 场景）
- 增加不依赖 telescope 的 quickfix 回退机制测试
- 补充 CMake 目标列表读取与 picker 构建的跨平台冒烟测试
- 收集并上传各平台的 CI 日志用于调试