### PR TITLE
feat(quick-c): 添加预设编译命令支持并优化模板处理

### DIFF
--- a/lua/quick-c/build.lua
+++ b/lua/quick-c/build.lua
@@ -131,6 +131,22 @@ local function scandir_files(dir)
   return out
 end
 
+local function expand_template_str(tmpl, vars)
+  local s = tostring(tmpl or '')
+  s = s:gsub('%%{sources%%}', '{sources}')
+  s = s:gsub('%%{out%%}', '{out}')
+  s = s:gsub('%%{cc%%}', '{cc}')
+  s = s:gsub('%%{ft%%}', '{ft}')
+  s = s:gsub('{out}', vars.out)
+  s = s:gsub('{cc}', vars.cc)
+  s = s:gsub('{ft}', vars.ft)
+  if s:find('{sources}', 1, true) then
+    local src = table.concat(vars.sources or {}, ' ')
+    s = s:gsub('{sources}', src)
+  end
+  return s
+end
+
 -- Async parallel BFS to discover candidate executables
 local function discover_candidates_async(config, is_win, start_dir, cb)
   local dbg = (config.debug or {})
@@ -429,6 +445,26 @@ local function clone_list(t)
   return o
 end
 
+local function add_preset_entry(entries, preset, idx)
+  local disp = nil
+  local value = preset
+  if type(preset) == 'table' then
+    if preset.name ~= nil and preset.cmd ~= nil then
+      disp = tostring(preset.name)
+      value = preset.cmd
+    elseif preset.display ~= nil and preset.cmd ~= nil then
+      disp = tostring(preset.display)
+      value = preset.cmd
+    else
+      disp = table.concat(preset, ' ')
+      value = preset
+    end
+  else
+    disp = tostring(preset)
+  end
+  table.insert(entries, { display = disp, kind = 'preset', value = value, idx = idx })
+end
+
 local function project_key()
   local root = vim.fn.getcwd()
   return require('quick-c.util').norm(root)
@@ -453,14 +489,17 @@ local function choose_user_compile_cmd_async(config, is_win, ft, sources, exe, b
   local entries = {}
   table.insert(entries, { display = '[Use built-in]', kind = 'builtin' })
   table.insert(entries, { display = '[Custom args...]', kind = 'args' })
-  for idx, p in ipairs(presets) do
-    local disp
-    if type(p) == 'table' then
-      disp = table.concat(p, ' ')
+  if type(presets) == 'table' then
+    local n = #presets
+    if n > 0 then
+      for idx, p in ipairs(presets) do
+        add_preset_entry(entries, p, idx)
+      end
     else
-      disp = tostring(p)
+      for k, p in pairs(presets) do
+        add_preset_entry(entries, p, k)
+      end
     end
-    table.insert(entries, { display = disp, kind = 'preset', value = p, idx = idx })
   end
   local function finalize(choice)
     if not choice then
@@ -473,13 +512,22 @@ local function choose_user_compile_cmd_async(config, is_win, ft, sources, exe, b
     end
     if choice.kind == 'preset' then
       local tmpl = choice.value
-      if type(tmpl) ~= 'table' then
-        -- string template unsupported for robust argv; fall back to builtin
-        cb(clone_list(builtin_cmd))
+      if type(tmpl) == 'table' then
+        local argv = expand_template_argv(tmpl, { sources = sources, out = exe, cc = cc or '', ft = ft })
+        cb(argv)
         return
       end
-      local argv = expand_template_argv(tmpl, { sources = sources, out = exe, cc = cc or '', ft = ft })
-      cb(argv)
+      if type(tmpl) == 'string' then
+        local expanded = expand_template_str(tmpl, { sources = sources, out = exe, cc = cc or '', ft = ft })
+        local argv = vim.fn.split(expanded)
+        if argv and #argv > 0 then
+          cb(argv)
+        else
+          cb(clone_list(builtin_cmd))
+        end
+        return
+      end
+      cb(clone_list(builtin_cmd))
       return
     end
     if choice.kind == 'args' then

--- a/lua/quick-c/config.lua
+++ b/lua/quick-c/config.lua
@@ -37,7 +37,10 @@ C.defaults = {
       -- 必须使用完整的编译命令，这不是追加参数
       -- 允许占位符：{sources} {out} {cc} {ft}
       -- 例如：{ 'gcc', '-g', '-O0', '{sources}', '-o', '{out}' }
-      presets = {},
+      presets = {
+        { name = "Debug", cmd = { "gcc", "-g", "-O0", "{sources}", "-o", "{out}" } },
+        { name = "ASan",  cmd = { "gcc", "-g", "-O0", "-fsanitize=address", "{sources}", "-o", "{out}" } },
+      },
       -- 自定义输入的默认模板（字符串或数组）。
       -- 这是弹窗后的追加命令
       default = nil,

--- a/markdown/cn/Default_configuration.md
+++ b/markdown/cn/Default_configuration.md
@@ -44,8 +44,10 @@
           -- 预设命令（推荐使用列表形式以避免 shell 解析问题）：
           -- 必须使用完整的编译命令，这不是追加参数
           -- 允许占位符：{sources} {out} {cc} {ft}
-          -- 例如：{ 'gcc', '-g', '-O0', '{sources}', '-o', '{out}' }
-          presets = {},
+          presets = {
+            { name = "Debug", cmd = { "gcc", "-g", "-O0", "{sources}", "-o", "{out}" } },
+            { name = "ASan",  cmd = { "gcc", "-g", "-O0", "-fsanitize=address", "{sources}", "-o", "{out}" } },
+          },
           -- 自定义输入的默认模板（字符串或数组）。
           -- 这是弹窗后的追加命令
           default = nil,


### PR DESCRIPTION
添加了 `expand_template_str` 函数用于处理字符串模板，
支持 `{sources}`、`{out}`、`{cc}`、`{ft}` 占位符替换。

新增 `add_preset_entry` 函数统一处理预设命令的显示和值。

重构了 `choose_user_compile_cmd_async` 函数，支持表格式预设配置，
包括 name/cmd 和 display/cmd 格式，并增强字符串模板处理。

更新默认配置，添加 Debug 和 ASan 预设命令示例。